### PR TITLE
merge results into development

### DIFF
--- a/src/DisplayGame.js
+++ b/src/DisplayGame.js
@@ -3,8 +3,6 @@ import {
     getNewDeck,
     drawCardsFromDeck,
     getHandTotalValue,
-    determineWinner,
-    getGameOverMessage,
 } from "./helpers/blackjack";
 
 import PokemonDisplay from "./PokemonDisplay";
@@ -183,132 +181,151 @@ const DisplayGame = () => {
         startGame();
     }, []);
 
-    useEffect(() => {
-        if (playerOneDone && playerTwoDone) {
-            // Here we can use the `determineWinner` function and evolve the pokemon.
-            console.log("game over");
-        }
-    }, [playerOneDone, playerTwoDone]);
+    // useEffect(() => {
+    //     if (playerOneDone && playerTwoDone) {
+    //         // Here we can use the `determineWinner` function and evolve the pokemon.
+    //         console.log("game over");
+    //     }
+    // }, [playerOneDone, playerTwoDone]);
 
     return (
         <section className="game">
             {error ? <p>Oh no! There was an error!</p> : null}
 
-            {playerOneDone && playerTwoDone && (
-                <>
-                    <Results />
-                    <p>
-                        {getGameOverMessage(
-                            determineWinner(playerOneTotal, playerTwoTotal)
-                        )}
-                    </p>
-                </>
-            )}
+            {
+                // If both players are done, then display Results screen
+                playerOneDone && playerTwoDone ? (
+                    <>
+                        <Results
+                            playerOneTotal={playerOneTotal}
+                            playerTwoTotal={playerTwoTotal}
+                            userOnePokemon={userOnePokemon}
+                            userTwoPokemon={userTwoPokemon}
+                        />
+                    </>
+                ) : // Based on the active player, re-render the Pokemon facing the correct direction
+                activePlayer === "player1" ? (
+                    <>
+                        <p>Player One's Turn!</p>
 
-            {activePlayer === "player1" ? (
-                <>
-                    <p>Player 1</p>
+                        <PokemonDisplay
+                            currentPoke={userOnePokemon}
+                            opponent={userTwoPokemon}
+                        />
 
-                    <PokemonDisplay
-                        currentPoke={userOnePokemon}
-                        opponent={userTwoPokemon}
-                    />
+                        <div className="current-hand">
+                            {playerOneHand.map((card) => {
+                                return (
+                                    <img
+                                        key={card.code}
+                                        src={card.image}
+                                        alt={card.code}
+                                    />
+                                );
+                            })}
+                        </div>
 
-                    <div className="current-hand">
-                        {playerOneHand.map((card) => {
-                            return (
-                                <img
-                                    key={card.code}
-                                    src={card.image}
-                                    alt={card.code}
-                                />
-                            );
-                        })}
-                    </div>
+                        {isPlayerOneBust && <p>BUST!</p>}
 
-                    {isPlayerOneBust && <p>BUST!</p>}
+                        <p>Total: {playerOneTotal}</p>
 
-                    <p>Total: {playerOneTotal}</p>
+                        <button
+                            disabled={
+                                playerOneDone || activePlayer !== "player1"
+                            }
+                            onClick={async () => {
+                                const newCards = await drawCardsFromDeck(
+                                    deckId,
+                                    1
+                                );
+                                const newHand = [...playerOneHand, ...newCards];
+                                const total = getHandTotalValue(newHand);
+                                setPlayerOneHand(newHand);
+                                if (total > 21) {
+                                    setPlayerOneDone(true);
+                                    setActivePlayer("player2");
+                                }
+                            }}
+                        >
+                            Hit
+                        </button>
 
-                    <button
-                        disabled={playerOneDone || activePlayer !== "player1"}
-                        onClick={async () => {
-                            const newCards = await drawCardsFromDeck(deckId, 1);
-                            const newHand = [...playerOneHand, ...newCards];
-                            const total = getHandTotalValue(newHand);
-                            setPlayerOneHand(newHand);
-                            if (total > 21) {
+                        <button
+                            disabled={
+                                playerOneDone || activePlayer !== "player1"
+                            }
+                            onClick={() => {
                                 setPlayerOneDone(true);
                                 setActivePlayer("player2");
+                            }}
+                        >
+                            Stand
+                        </button>
+                    </>
+                ) : (
+                    <>
+                        <p>Player Two's Turn!</p>
+
+                        <PokemonDisplay
+                            currentPoke={userTwoPokemon}
+                            opponent={userOnePokemon}
+                        />
+
+                        <div className="current-hand">
+                            {playerTwoHand.map((card) => {
+                                return (
+                                    <img
+                                        key={card.code}
+                                        src={card.image}
+                                        alt={card.code}
+                                    />
+                                );
+                            })}
+                        </div>
+
+                        {isPlayerTwoBust && <p>BUST!</p>}
+
+                        <p>Total: {playerTwoTotal}</p>
+
+                        <button
+                            disabled={
+                                playerTwoDone || activePlayer !== "player2"
                             }
-                        }}
-                    >
-                        Hit
-                    </button>
+                            onClick={async () => {
+                                const newCards = await drawCardsFromDeck(
+                                    deckId,
+                                    1
+                                );
+                                const newHand = [...playerTwoHand, ...newCards];
+                                const total = getHandTotalValue(newHand);
+                                setPlayerTwoHand(newHand);
+                                if (total > 21) {
+                                    setPlayerTwoDone(true);
+                                    setActivePlayer("player1");
+                                }
+                            }}
+                        >
+                            Hit
+                        </button>
 
-                    <button
-                        disabled={playerOneDone || activePlayer !== "player1"}
-                        onClick={() => {
-                            setPlayerOneDone(true);
-                            setActivePlayer("player2");
-                        }}
-                    >
-                        Stand
-                    </button>
-                </>
-            ) : (
-                <>
-                    <p>Player 2</p>
-
-                    <PokemonDisplay
-                        currentPoke={userTwoPokemon}
-                        opponent={userOnePokemon}
-                    />
-
-                    <div className="current-hand">
-                        {playerTwoHand.map((card) => {
-                            return (
-                                <img
-                                    key={card.code}
-                                    src={card.image}
-                                    alt={card.code}
-                                />
-                            );
-                        })}
-                    </div>
-
-                    {isPlayerTwoBust && <p>BUST!</p>}
-
-                    <p>Total: {playerTwoTotal}</p>
-
-                    <button
-                        disabled={playerTwoDone || activePlayer !== "player2"}
-                        onClick={async () => {
-                            const newCards = await drawCardsFromDeck(deckId, 1);
-                            const newHand = [...playerTwoHand, ...newCards];
-                            const total = getHandTotalValue(newHand);
-                            setPlayerTwoHand(newHand);
-                            if (total > 21) {
+                        <button
+                            disabled={
+                                playerTwoDone || activePlayer !== "player2"
+                            }
+                            onClick={() => {
                                 setPlayerTwoDone(true);
                                 setActivePlayer("player1");
-                            }
-                        }}
-                    >
-                        Hit
-                    </button>
+                            }}
+                        >
+                            Stand
+                        </button>
+                    </>
+                )
+            }
 
-                    <button
-                        disabled={playerTwoDone || activePlayer !== "player2"}
-                        onClick={() => {
-                            setPlayerTwoDone(true);
-                            setActivePlayer("player1");
-                        }}
-                    >
-                        Stand
-                    </button>
-                </>
-            )}
-
+            {
+                // If both players are done, then display reset button
+            }
             {playerOneDone && playerTwoDone && (
                 <div>
                     <button

--- a/src/DisplayGame.js
+++ b/src/DisplayGame.js
@@ -7,6 +7,7 @@ import {
 
 import PokemonDisplay from "./PokemonDisplay";
 import Results from "./Results";
+import Hand from "./Hand";
 
 const DisplayGame = () => {
     // Variables to store Pokemon that can evolve for both users
@@ -213,17 +214,7 @@ const DisplayGame = () => {
                             opponent={userTwoPokemon}
                         />
 
-                        <div className="current-hand">
-                            {playerOneHand.map((card) => {
-                                return (
-                                    <img
-                                        key={card.code}
-                                        src={card.image}
-                                        alt={card.code}
-                                    />
-                                );
-                            })}
-                        </div>
+                        <Hand cards={playerOneHand} />
 
                         {isPlayerOneBust && <p>BUST!</p>}
 
@@ -271,17 +262,7 @@ const DisplayGame = () => {
                             opponent={userOnePokemon}
                         />
 
-                        <div className="current-hand">
-                            {playerTwoHand.map((card) => {
-                                return (
-                                    <img
-                                        key={card.code}
-                                        src={card.image}
-                                        alt={card.code}
-                                    />
-                                );
-                            })}
-                        </div>
+                        <Hand cards={playerTwoHand} />
 
                         {isPlayerTwoBust && <p>BUST!</p>}
 

--- a/src/DisplayGame.js
+++ b/src/DisplayGame.js
@@ -9,12 +9,14 @@ import {
 
 import PokemonDisplay from "./PokemonDisplay";
 import Results from "./Results";
-import Hand from "./Hand";
 
 const DisplayGame = () => {
     // Variables to store Pokemon that can evolve for both users
     const [userOnePokemon, setUserOnePokemon] = useState({});
     const [userTwoPokemon, setUserTwoPokemon] = useState({});
+
+    // Number of rounds played, initialize at round 1
+    const [numOfRounds, setNumOfRounds] = useState(1);
 
     const [deckId, setDeckId] = useState();
     const [error, setError] = useState(false);
@@ -69,6 +71,7 @@ const DisplayGame = () => {
     const setRandomChoice = (res, user) => {
         // Make a request to the next endpoint where we want to save data from
         const nextRequestURL = res.chain.species.url.replace("-species", "");
+        console.log("now displaying", res.chain.species.name);
 
         // A function that accepts a pokemon object as a parameter and randomly determines if it is shiny
         const areYouShiny = (pokemon) => {
@@ -110,7 +113,7 @@ const DisplayGame = () => {
     useEffect(() => {
         pickAPokemon("first");
         pickAPokemon("second");
-    }, []);
+    }, [numOfRounds]);
 
     async function startGame() {
         try {
@@ -131,6 +134,7 @@ const DisplayGame = () => {
         setPlayerTwoHand([]);
         setPlayerOneDone(false);
         setPlayerTwoDone(false);
+        setNumOfRounds(numOfRounds + 1);
     }
 
     useEffect(() => {
@@ -168,7 +172,17 @@ const DisplayGame = () => {
                         opponent={userTwoPokemon}
                     />
 
-                    <Hand cards={playerOneHand} />
+                    <div className="current-hand">
+                        {playerOneHand.map((card) => {
+                            return (
+                                <img
+                                    key={card.code}
+                                    src={card.image}
+                                    alt={card.code}
+                                />
+                            );
+                        })}
+                    </div>
 
                     {isPlayerOneBust && <p>BUST!</p>}
 
@@ -209,7 +223,17 @@ const DisplayGame = () => {
                         opponent={userOnePokemon}
                     />
 
-                    <Hand cards={playerTwoHand} />
+                    <div className="current-hand">
+                        {playerTwoHand.map((card) => {
+                            return (
+                                <img
+                                    key={card.code}
+                                    src={card.image}
+                                    alt={card.code}
+                                />
+                            );
+                        })}
+                    </div>
 
                     {isPlayerTwoBust && <p>BUST!</p>}
 

--- a/src/Results.js
+++ b/src/Results.js
@@ -1,9 +1,49 @@
-const Results = () => {
+import { useEffect, useState } from "react";
+import { getGameOverMessage, determineWinner } from "./helpers/blackjack";
+
+const Results = (props) => {
+    const determinedWinner = determineWinner(
+        props.playerOneTotal,
+        props.playerTwoTotal
+    );
+    const resultMessage = getGameOverMessage(determinedWinner);
+    const [gameWinner, setGameWinner] = useState({});
+
+    // On component mount, check who has won the game.
+    useEffect(() => {
+        if (determinedWinner === "player1") {
+            setGameWinner(props.userOnePokemon);
+        } else if (determinedWinner === "player2") {
+            setGameWinner(props.userTwoPokemon);
+        } else {
+            setGameWinner({});
+        }
+    }, [determinedWinner, props.userOnePokemon, props.userTwoPokemon]);
+
     return (
         <section className="results">
-            <h2>This is the results component</h2>
+            <div className="results-message">
+                <h2>Good game!</h2>
+                <p>{resultMessage}</p>
+            </div>
+            <div className="evolution-display">
+                {
+                    // If determined winner is null, then show tie message, otherwise show the game winner
+                    determinedWinner ? (
+                        <p>
+                            Your{" "}
+                            {`${gameWinner.name} has evolved into ${gameWinner.evoName}!`}
+                        </p>
+                    ) : (
+                        <p>
+                            It appears you have both tied. Win the game to
+                            evolve your Pokemon!
+                        </p>
+                    )
+                }
+            </div>
         </section>
-    )
-}
+    );
+};
 
-export default Results; 
+export default Results;

--- a/src/Results.js
+++ b/src/Results.js
@@ -20,30 +20,40 @@ const Results = (props) => {
         }
     }, [determinedWinner, props.userOnePokemon, props.userTwoPokemon]);
 
-    return (
-        <section className="results">
-            <div className="results-message">
-                <h2>Good game!</h2>
-                <p>{resultMessage}</p>
-            </div>
-            <div className="evolution-display">
-                {
-                    // If determined winner is null, then show tie message, otherwise show the game winner
-                    determinedWinner ? (
-                        <p>
-                            Your{" "}
-                            {`${gameWinner.name} has evolved into ${gameWinner.evoName}!`}
-                        </p>
-                    ) : (
-                        <p>
-                            It appears you have both tied. Win the game to
-                            evolve your Pokemon!
-                        </p>
-                    )
-                }
-            </div>
-        </section>
-    );
+    if (gameWinner.evoSprites) {
+        return (
+            <section className="results">
+                <div className="results-message">
+                    <h2>Good game!</h2>
+                    <p>{resultMessage}</p>
+                </div>
+                <div className="evolution-display">
+                    {
+                        // If determined winner is null, then show tie message, otherwise show the game winner
+                        determinedWinner ? (
+                            <div className="winnerDisplay">
+                                <p>
+                                    Your{" "}
+                                    {`${gameWinner.name} has evolved into ${gameWinner.evoName}!`}
+                                </p>
+                                <img
+                                    src={`${gameWinner.evoSprites.front}`}
+                                    alt=""
+                                />
+                            </div>
+                        ) : (
+                            <p>
+                                It appears you have both tied. Win the game to
+                                evolve your Pokemon!
+                            </p>
+                        )
+                    }
+                </div>
+            </section>
+        );
+    } else {
+        return <h2>Loading...</h2>;
+    }
 };
 
 export default Results;


### PR DESCRIPTION
- Pokemon will now re-roll when "Play Again" is selected.

- A Pokemon's immediate evolution (name and urls to front and back sprites [with consideration to whether or not it is shiny]) is now also stored within the same state where it lives within DisplayGame -- what does this mean? We have the predecessor and the evolution in the same spot - we could use this to do things like create a fake evolution "animation" if we wanted to

- "Results" will also now re-render on its own without the PokemonDisplay component showing as well

![image](https://user-images.githubusercontent.com/72824116/159617357-85e136e1-d897-4ac4-bbe0-18bf737f19e9.png)


- I couldn't get the evolution images to render for some reason within the Results component, so I could use some help with that eventually. It is, however, already passed down as a prop to the results component and exists within it. I keep running into an issue where React claims that the state where I am holding winners doesn't exist. That may the next item to tackle within this series of features.