### PR TITLE
add turn buttons and display ties in result component accurately

### DIFF
--- a/src/DisplayGame.js
+++ b/src/DisplayGame.js
@@ -1,3 +1,4 @@
+// hi ish
 import { useState, useEffect } from "react";
 import {
     getNewDeck,
@@ -178,16 +179,29 @@ const DisplayGame = () => {
         setNumOfRounds(numOfRounds + 1);
     }
 
+    async function handlePlayerOneHit() {
+        const newCards = await drawCardsFromDeck(deckId, 1);
+        const newHand = [...playerOneHand, ...newCards];
+        const total = getHandTotalValue(newHand);
+        setPlayerOneHand(newHand);
+        if (total > 21) {
+            setPlayerOneDone(true);
+        }
+    }
+
+    async function handlePlayerTwoHit() {
+        const newCards = await drawCardsFromDeck(deckId, 1);
+        const newHand = [...playerTwoHand, ...newCards];
+        const total = getHandTotalValue(newHand);
+        setPlayerTwoHand(newHand);
+        if (total > 21) {
+            setPlayerTwoDone(true);
+        }
+    }
+
     useEffect(() => {
         startGame();
     }, []);
-
-    // useEffect(() => {
-    //     if (playerOneDone && playerTwoDone) {
-    //         // Here we can use the `determineWinner` function and evolve the pokemon.
-    //         console.log("game over");
-    //     }
-    // }, [playerOneDone, playerTwoDone]);
 
     return (
         <section className="game">
@@ -206,6 +220,7 @@ const DisplayGame = () => {
                     </>
                 )
             }
+
             {
                 // Based on the active player, re-render the Pokemon facing the correct direction
                 activePlayer === "player1" ? (
@@ -227,19 +242,7 @@ const DisplayGame = () => {
                             disabled={
                                 playerOneDone || activePlayer !== "player1"
                             }
-                            onClick={async () => {
-                                const newCards = await drawCardsFromDeck(
-                                    deckId,
-                                    1
-                                );
-                                const newHand = [...playerOneHand, ...newCards];
-                                const total = getHandTotalValue(newHand);
-                                setPlayerOneHand(newHand);
-                                if (total > 21) {
-                                    setPlayerOneDone(true);
-                                    setActivePlayer("player2");
-                                }
-                            }}
+                            onClick={handlePlayerOneHit}
                         >
                             Hit
                         </button>
@@ -250,11 +253,20 @@ const DisplayGame = () => {
                             }
                             onClick={() => {
                                 setPlayerOneDone(true);
-                                setActivePlayer("player2");
                             }}
                         >
                             Stand
                         </button>
+
+                        {playerOneDone && !playerTwoDone ? (
+                            <button
+                                onClick={() => {
+                                    setActivePlayer("player2");
+                                }}
+                            >
+                                Player Two's Turn!
+                            </button>
+                        ) : null}
                     </>
                 ) : (
                     <>
@@ -275,19 +287,7 @@ const DisplayGame = () => {
                             disabled={
                                 playerTwoDone || activePlayer !== "player2"
                             }
-                            onClick={async () => {
-                                const newCards = await drawCardsFromDeck(
-                                    deckId,
-                                    1
-                                );
-                                const newHand = [...playerTwoHand, ...newCards];
-                                const total = getHandTotalValue(newHand);
-                                setPlayerTwoHand(newHand);
-                                if (total > 21) {
-                                    setPlayerTwoDone(true);
-                                    setActivePlayer("player1");
-                                }
-                            }}
+                            onClick={handlePlayerTwoHit}
                         >
                             Hit
                         </button>
@@ -298,11 +298,20 @@ const DisplayGame = () => {
                             }
                             onClick={() => {
                                 setPlayerTwoDone(true);
-                                setActivePlayer("player1");
                             }}
                         >
                             Stand
                         </button>
+
+                        {playerTwoDone && !playerOneDone ? (
+                            <button
+                                onClick={() => {
+                                    setActivePlayer("player1");
+                                }}
+                            >
+                                Player One's Turn!
+                            </button>
+                        ) : null}
                     </>
                 )
             }

--- a/src/Results.js
+++ b/src/Results.js
@@ -2,18 +2,27 @@ import { useEffect, useState } from "react";
 import { getGameOverMessage, determineWinner } from "./helpers/blackjack";
 
 const Results = (props) => {
+    // Uses helper function to determine which user has won, returns
     const determinedWinner = determineWinner(
         props.playerOneTotal,
         props.playerTwoTotal
     );
     const resultMessage = getGameOverMessage(determinedWinner);
+    // State that tracks who has won using the helper function
+    const [gameWinner, setGameWinner] = useState({});
 
-    let gameWinner = {};
-    if (determinedWinner === "player1") {
-        gameWinner = props.userOnePokemon;
-    } else if (determinedWinner === "player2") {
-        gameWinner = props.userTwoPokemon;
-    }
+    // On component mount, check who has won the game.
+    useEffect(() => {
+        if (determinedWinner === "player1") {
+            const dummy = props.userOnePokemon;
+            setGameWinner(dummy);
+        } else if (determinedWinner === "player2") {
+            const dummy = props.userTwoPokemon;
+            setGameWinner(dummy);
+        } else {
+            setGameWinner({});
+        }
+    }, [determinedWinner, props.userOnePokemon, props.userTwoPokemon]);
 
     if (gameWinner.evoSprites) {
         return (
@@ -24,8 +33,9 @@ const Results = (props) => {
                 </div>
                 <div className="evolution-display">
                     {
-                        // If determined winner is null, then show tie message, otherwise show the game winner
-                        determinedWinner ? (
+                        // If determined winner is not player1, player2, or there is no tie
+                        determinedWinner === "player1" ||
+                        determinedWinner === "player2" ? (
                             <div className="winnerDisplay">
                                 <p>
                                     Your{" "}
@@ -36,15 +46,17 @@ const Results = (props) => {
                                     alt=""
                                 />
                             </div>
-                        ) : (
-                            <p>
-                                It appears you have both tied. Win the game to
-                                evolve your Pokemon!
-                            </p>
-                        )
+                        ) : null
                     }
                 </div>
             </section>
+        );
+    } else if (Object.keys(gameWinner).length === 0) {
+        return (
+            <p>
+                It appears you have both tied. Win the game to evolve your
+                Pokemon!
+            </p>
         );
     } else {
         return <h2>Loading...</h2>;

--- a/src/helpers/blackjack.js
+++ b/src/helpers/blackjack.js
@@ -52,6 +52,7 @@ export function determineWinner(playerOneTotal, playerTwoTotal) {
         return "player1";
     } else if (playerOneTotal === playerTwoTotal) {
         // Also a tie
+        // return "tie";
         return null;
     } else {
         return playerOneTotal > playerTwoTotal ? "player1" : "player2";


### PR DESCRIPTION
- Added turn buttons, so now after every turn is complete (and before the users are switched), the game will prompt the user to go to the next turn. @allisonvilla and I feel like this works better with the "hot seat" nature of the game. 

- Re-factored some of the button onClick code for "Hits" and "Stands". Moved it out of the onClick attribute and into its own function.

- Re-implemented old Results logic (sorry, @rachellehanna) -- the new logic was breaking how results and sprites were loading/preventing them from rendering properly. We are now again considering using a state to keep track of who the winner is, as that is what our renders are contingent upon. We also find that it helps contain the logic within Results and out of DisplayGame. 

Busts actually show now instead of switching turns right away.
![image](https://user-images.githubusercontent.com/72824116/159804425-3e1e1f67-78d5-4a99-bd17-0f6661757ac1.png)

